### PR TITLE
go.mod: update package name

### DIFF
--- a/cli/cli/run.go
+++ b/cli/cli/run.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/wassimbenzarti/github-notifier/features"
+	"github.com/wassimbenzarti/github-notifier/cli/features"
 )
 
 var runCommand = &cobra.Command{

--- a/cli/features/notifications.go
+++ b/cli/features/notifications.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/gen2brain/beeep"
-	"github.com/wassimbenzarti/github-notifier/github"
-	"github.com/wassimbenzarti/github-notifier/terminal"
+	"github.com/wassimbenzarti/github-notifier/cli/github"
+	"github.com/wassimbenzarti/github-notifier/cli/terminal"
 )
 
 type QueryRequestBody struct {
@@ -87,5 +87,4 @@ func RunNotifications(organization string, team string, author string, teamMembe
 			beeep.Alert("GH Notifier", strings.Join(messages, "\n"), "assets/notification.png")
 		}
 	}
-
 }

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,4 +1,4 @@
-module github.com/wassimbenzarti/github-notifier
+module github.com/wassimbenzarti/github-notifier/cli
 
 go 1.22.4
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/wassimbenzarti/github-notifier/cli"
+import "github.com/wassimbenzarti/github-notifier/cli/cli"
 
 func main() {
 	cli.Execute()


### PR DESCRIPTION
Using the "correct" package name allows users to install the cli with
`go`. eg
```
go install github.com/wassimbenzarti/github-notifier/cli@latest
```

Alternativly we could remove the cli directory in the root of the repo.
In that case the binary would be called `github-notifier` instead of
`cli`. Maybe nicer.
