### PR TITLE
Improve notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,4 @@ On startup, we check the new reviews and checks that were completed in the last 
 # Known limitations
 1. One person in the team reviewing all PRs might eventually impact the quality of code (this tool doesn't notify you about already reviewed PRs)
 2. Notifications can always be a subjectively distracting, so you have to use it wisely. Currently this tool doesn't support features to limit the distractions (e.g. only alert if there are more than 3 events)
-3. Drafts brings you a notification
-4. If you review a PR but don't approve it, the owner of the PR needs to request your review again (by clicking the "request again" button on GitHub) to get a notification
+3. If you review a PR but don't approve it, the owner of the PR needs to request your review again (by clicking the "request again" button on GitHub) to get a notification

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -25,7 +25,10 @@ var rootCmd = &cobra.Command{
 	Short: "GitHub notifier",
 	Long:  `A CLI for pushing notifications of important GitHub events (Review required, Review received, Checks done, etc.)`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		slog.SetLogLoggerLevel(slog.Level(logLevel))
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			AddSource: true,
+			Level:     slog.Level(logLevel),
+		})))
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()


### PR DESCRIPTION
Don't show PRs that are in draft.

Instead of only showing PRs that were created within the last day, show
PRs that were updated within the last 3 days. (yesterday + weekend)

Add the last updated time to the notifications so users can tell how up
to date PRs are when they first start the notifier. (linux only)
